### PR TITLE
Fix header width issue when BigBuys still loading.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "drip-multi-wallet-dashboard",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "dependencies": {
         "@jpmonette/bscscan": "^0.2.3",
         "@testing-library/jest-dom": "^5.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": true,
   "dependencies": {
     "@jpmonette/bscscan": "^0.2.3",

--- a/src/App.css
+++ b/src/App.css
@@ -95,9 +95,7 @@ textarea.invert {
   .controls {
     display: block !important;
   }
-  /* .navbar {
-    max-width: min-content;
-  } */
+  
   .navbar-brand {
     margin-right: 0px;
   }

--- a/src/App.css
+++ b/src/App.css
@@ -95,9 +95,9 @@ textarea.invert {
   .controls {
     display: block !important;
   }
-  .navbar {
+  /* .navbar {
     max-width: min-content;
-  }
+  } */
   .navbar-brand {
     margin-right: 0px;
   }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -75,7 +75,7 @@ const Header = () => {
     <nav className="navbar navbar-expand-lg nav-wrap fixed-top navbar-dark bg-dark inverted">
       <div className="container-fluid">
         <div className="navbar-brand">
-          <Link to={"/drip-mw-dashboard"}>Drip Multi-Wallet Dashboard</Link>
+          <Link to={"/"}>Drip Multi-Wallet Dashboard</Link>
           {compareVersions() && (
             <div style={{ marginLeft: 25 }}>
               New version{" "}


### PR DESCRIPTION
There was some old css that was setting the header max-width to min-content for small screens. That was causing the header to be short while the BigBuys data was still loading.  Removed it so the header is full width initially.
Also changed the Link path value in the header to '/' instead of '/drip-mw-dashboard' as that is now the host name anyways.