### PR TITLE
Fix timezone for big buys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "drip-multi-wallet-dashboard",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@jpmonette/bscscan": "^0.2.3",
         "@testing-library/jest-dom": "^5.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "dependencies": {
     "@jpmonette/bscscan": "^0.2.3",

--- a/src/components/BigDripBuys.jsx
+++ b/src/components/BigDripBuys.jsx
@@ -59,7 +59,7 @@ const BigDripBuys = () => {
           >
             {bb.amount} BNB {bb.dripAmt && <span>({bb.dripAmt} Drip)</span>}
           </a>{" "}
-          on {bb.date} -{" "}
+          on {new Date(bb.timestamp).toLocaleString()} -{" "}
         </div>
       ))}
       <span style={{ marginRight: "50px" }}>Updated: {updateTime}</span>


### PR DESCRIPTION
Originally, big buys was called by code in the browser, so the transaction date was already formatted for the local timezone. When it migrated to AWS, the date format was set based on the server, so always shows GMT.  returned the date as a raw timestamp so that the browser can still format it for local timezone for display.