### PR TITLE
Last action will reset on column sort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "drip-multi-wallet-dashboard",
-      "version": "1.12.7",
+      "version": "1.12.8",
       "dependencies": {
         "@jpmonette/bscscan": "^0.2.3",
         "@testing-library/jest-dom": "^5.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -122,7 +122,9 @@ const Dashboard = () => {
       return;
     }
     try {
-      wallets?.length > 1 && wallets?.sort(sortBy(sortCol, sortOrder));
+      if (wallets?.length > 1) {
+        wallets?.sort(sortBy(sortCol, sortOrder));
+      }
     } catch (err) {
       console.log(`error sorting wallets: ${err.message}`);
     }

--- a/src/components/TableRow.jsx
+++ b/src/components/TableRow.jsx
@@ -5,7 +5,7 @@ import {
   formatNumber,
 } from "../api/utils";
 import { Link } from "react-router-dom";
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getLastAction, getStartBlock } from "../api/Contract";
 const TableRow = ({
   index,
@@ -28,7 +28,7 @@ const TableRow = ({
 
   const fetchLastAction = async () => {
     setLoading(true);
-    setLastAction(" ");
+    //setLastAction(" ");
     // await new Promise((resolve) =>
     //   setTimeout(() => {
     //     resolve(true);
@@ -44,10 +44,20 @@ const TableRow = ({
       );
       await fetchLastAction();
     } else {
-      response && setLastAction(response);
+      setLastAction(response);
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    setLastAction("-");
+  }, [wallet.address]);
+
+  // useEffect(() => {
+  //   setTimeout(() => {
+  //     fetchLastAction();
+  //   }, 1000 * index);
+  // }, [fetchLastAction, index]);
 
   if (!wallet) return <></>;
   return (
@@ -130,7 +140,7 @@ const TableRow = ({
           style={{ cursor: "pointer", textAlign: "center" }}
           className={loading ? "dotloading" : ""}
         >
-          {lastAction || "-"}
+          {lastAction}
         </td>
       )}
       <td


### PR DESCRIPTION
Last action is retrieved on click of the column, but when sorting the columns, the value does not follow the row. Instead, it stays on the same row.  Resetting the value when the row data changes, like when sorting or refreshing the data.