### PR TITLE
Update br34p link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "drip-multi-wallet-dashboard",
-      "version": "1.23.2",
+      "version": "1.23.3",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -196,7 +196,7 @@ const Header = () => {
             </div>
             <div className="price stack">
               <a
-                href="https://v1exchange.pancakeswap.finance/#/swap?inputCurrency=0xa86d305A36cDB815af991834B46aD3d7FbB38523&outputCurrency=0xe9e7cea3dedca5984780bafc599bd69add087d56"
+                href="https://poocoin.app/tokens/0xa86d305a36cdb815af991834b46ad3d7fbb38523"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
The link used to go to the v1 PCS site to buy br34p.
The v1 exchange site is gone now, so directing to Poocoin,
where you can still select V1 PCS when buying