### PR TITLE
Disable cache for downline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.23.5",
+  "version": "1.23.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "drip-multi-wallet-dashboard",
-      "version": "1.23.5",
+      "version": "1.23.6",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.23.5",
+  "version": "1.23.6",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/src/api/Contract.js
+++ b/src/api/Contract.js
@@ -255,9 +255,9 @@ export const roll = async (account) => {
 };
 
 export const getDownline = async (account) => {
-  if (downlineCache.has(account)) {
-    return downlineCache.get(account);
-  }
+  // if (downlineCache.has(account)) {
+  //   return downlineCache.get(account);
+  // }
   try {
     const downline = await axios.get(
       `https://api.drip.community/org/${account}`,

--- a/src/components/Downline.jsx
+++ b/src/components/Downline.jsx
@@ -23,7 +23,7 @@ function getObjectDepth(obj) {
 }
 
 const Downline = () => {
-  const [downline, setDownline] = useState();
+  const [downline, setDownline] = useState({});
   const { account } = useParams();
   const [depth, setDepth] = useState(0);
   const [isError, setIsError] = useState(false);


### PR DESCRIPTION
Cache is not working correctly and causing the downline page to fail to render the list until it is refreshed.