### PR TITLE
Display max claimable after Faucet retirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.28.4",
+  "version": "1.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "drip-multi-wallet-dashboard",
-      "version": "1.28.4",
+      "version": "1.29.0",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drip-multi-wallet-dashboard",
-  "version": "1.28.4",
+  "version": "1.29.0",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/src/api/Contract.js
+++ b/src/api/Contract.js
@@ -565,6 +565,9 @@ export const fetchWalletData = async (wallet, index, retry = false) => {
       referrals: parseInt(userInfo.referrals),
       whaleTax,
     };
+    // console.log(
+    //   `deposits: ${walletProfile.deposits}, available: ${walletProfile.available}, payouts: ${walletProfile.payouts}, rolls: ${walletProfile.r}`
+    // );
     return walletProfile;
   } catch (err) {
     if (!retry) {

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -143,3 +143,5 @@ export const calculateDaysToMaxDeposits = (initialDeposits, initialClaimed) => {
 
   return days;
 };
+
+export const negativeToZero = (amount) => (amount < 0 ? 0 : amount);

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -107,7 +107,7 @@ const Dashboard = () => {
     { label: "Hydrated", id: "r", expanded: true },
     { label: "Paid Out", id: "paidOut", expanded: true },
     { label: "Rewarded", id: "direct_bonus" },
-    { label: "Max Payout", id: "maxPayout" },
+    { label: "Max Claimable", id: "maxPayout" },
     { label: "Team", id: "referrals" },
     { label: "Ref Pos", id: "ref_claim_pos" },
   ];
@@ -389,7 +389,11 @@ const Dashboard = () => {
     );
     setTotalMax(() =>
       validWallets.reduce(
-        (total, wallet) => total + parseFloat(wallet.maxPayout),
+        (total, wallet) =>
+          total +
+          parseFloat(
+            wallet.deposits + wallet.available - (wallet.payouts - wallet.r)
+          ),
         0
       )
     );

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -17,6 +17,7 @@ import {
   backupData,
   formatNumber,
   sortBy,
+  negativeToZero,
 } from "../api/utils";
 
 import TableRow from "./TableRow";
@@ -392,7 +393,9 @@ const Dashboard = () => {
         (total, wallet) =>
           total +
           parseFloat(
-            wallet.deposits + wallet.available - (wallet.payouts - wallet.r)
+            negativeToZero(
+              wallet.deposits + wallet.available - (wallet.payouts - wallet.r)
+            )
           ),
         0
       )

--- a/src/components/TableRow.jsx
+++ b/src/components/TableRow.jsx
@@ -234,7 +234,11 @@ const TableRow = ({
                     )} */}
       </td>
       <td>
-        {convertTokenToUSD(wallet.maxPayout, dripPrice, showDollarValues)}
+        {convertTokenToUSD(
+          wallet.deposits + wallet.available - (wallet.payouts - wallet.r),
+          dripPrice,
+          showDollarValues
+        )}
       </td>
       <td>
         {wallet.referrals > 0 && (

--- a/src/components/TableRow.jsx
+++ b/src/components/TableRow.jsx
@@ -4,6 +4,7 @@ import {
   formatPercent,
   formatNumber,
   calculateDaysToMaxDeposits,
+  negativeToZero,
 } from "../api/utils";
 import { Link } from "react-router-dom";
 import { useState, useEffect } from "react";
@@ -235,7 +236,9 @@ const TableRow = ({
       </td>
       <td>
         {convertTokenToUSD(
-          wallet.deposits + wallet.available - (wallet.payouts - wallet.r),
+          negativeToZero(
+            wallet.deposits + wallet.available - (wallet.payouts - wallet.r)
+          ),
           dripPrice,
           showDollarValues
         )}


### PR DESCRIPTION
The Faucet is going to be essentially retired by restricting the ability to hydrate and create new wallets.  In the meantime, the contract will be updated to allow for max payout based on the current deposits.  The updated Max Claimable represents the calculation:  deposits + available - (paid out to wallet: claims - hydrates)